### PR TITLE
Add support for svn export

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ NOTE:
 Role Variables
 --------------
 
-| Variable              | Description                             | Default                                      |
-|-----------------------|-----------------------------------------|----------------------------------------------|
-| **nerdfonts_fonts[]** | List of nerdfonts to be installed       | see [`defaults/main.yml`](defaults/main.yml) |
-| **nerdfonts_mono**    | Install mono font variation             | `no`                                         |
-| **nerdfonts_users[]** | List of users nerdfonts to be installed | see [`defaults/main.yml`](defaults/main.yml) |
+| Variable               | Description                                        | Default                                      |
+|------------------------|----------------------------------------------------|----------------------------------------------|
+| **nerdfonts_fonts[]**  | List of nerdfonts to be installed                  | see [`defaults/main.yml`](defaults/main.yml) |
+| **nerdfonts_mono**     | Install mono font variation                        | `no`                                         |
+| **nerdfonts_users[]**  | List of users nerdfonts to be installed            | see [`defaults/main.yml`](defaults/main.yml) |
+| **nerdfonts_checkout** | Checkout nerdfonts via `svn` export or `git` clone | see [`defaults/main.yml`](defaults/main.yml) | 
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 nerdfonts_users: [ root ]
 nerdfonts_git_dest: "/tmp/nerd_fonts"
 nerdfonts_mono: no  # yes | no -- install mono variant of the font
-nerdfonts_checkout: git  # svn | git -- svn export or git clone
+nerdfonts_checkout: auto  # svn | git | auto -- svn export, git clone, or auto-detect
 
 nerdfonts_fonts:
 #  - fontname: '3270'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 nerdfonts_users: [ root ]
 nerdfonts_git_dest: "/tmp/nerd_fonts"
 nerdfonts_mono: no  # yes | no -- install mono variant of the font
+nerdfonts_checkout: git  # svn | git -- svn export or git clone
 
 nerdfonts_fonts:
 #  - fontname: '3270'

--- a/tasks/checkout-fonts.yml
+++ b/tasks/checkout-fonts.yml
@@ -1,11 +1,26 @@
 ---
+- name: '[Linux] Export files from the nerdfonts repo'
+  subversion:
+    repo: "https://github.com/ryanoasis/nerd-fonts.git/trunk/patched-fonts/{{ item.fontname }}"
+    dest: "{{ nerdfonts_git_dest }}/patched-fonts/{{ item.fontname }}"
+    export: yes
+  when:
+    - nerdfonts_checkout == 'svn'
+    - not item.installed
+  with_items:
+    - "{{ nerdfonts_exists }}"
+  become: yes
+  become_user: root
+
 - name: '[Linux] Clone the nerdfonts repo'
   git:
     repo: https://github.com/ryanoasis/nerd-fonts.git
     dest: "{{ nerdfonts_git_dest }}"
     depth: 1
     version: master
-  when: false in nerdfonts_install_statuses
+  when: 
+    - nerdfonts_checkout == 'git'
+    - false in nerdfonts_install_statuses
   become: yes
   become_user: root
 

--- a/tasks/checkout-fonts.yml
+++ b/tasks/checkout-fonts.yml
@@ -1,4 +1,27 @@
 ---
+- name: '[Linux] Detect checkout type'
+  shell: command -v svn
+  register: svn_check
+  ignore_errors: yes
+  when:
+    - nerdfonts_checkout == 'auto'
+  become: yes
+  become_user: root
+
+- name: '[Linux] Use git clone to checkout'
+  set_fact:
+    nerdfonts_checkout: git
+  when:
+    - nerdfonts_checkout == 'auto'
+    - svn_check.failed
+
+- name: '[Linux] Use svn export to checkout'
+  set_fact:
+    nerdfonts_checkout: svn
+  when:
+    - nerdfonts_checkout == 'auto'
+    - not svn_check.failed
+
 - name: '[Linux] Export files from the nerdfonts repo'
   subversion:
     repo: "https://github.com/ryanoasis/nerd-fonts.git/trunk/patched-fonts/{{ item.fontname }}"
@@ -23,4 +46,3 @@
     - false in nerdfonts_install_statuses
   become: yes
   become_user: root
-

--- a/tasks/checkout-fonts.yml
+++ b/tasks/checkout-fonts.yml
@@ -1,0 +1,11 @@
+---
+- name: '[Linux] Clone the nerdfonts repo'
+  git:
+    repo: https://github.com/ryanoasis/nerd-fonts.git
+    dest: "{{ nerdfonts_git_dest }}"
+    depth: 1
+    version: master
+  when: false in nerdfonts_install_statuses
+  become: yes
+  become_user: root
+

--- a/tasks/install-fonts.yml
+++ b/tasks/install-fonts.yml
@@ -35,15 +35,8 @@
   set_fact:
     nerdfonts_install_cmd: "rsync -av --no-owner --prune-empty-dirs --include='*/' --include='*.ttf' --exclude='*'"
 
-- name: '[Linux] Clone the nerdfonts repo'
-  git:
-    repo: https://github.com/ryanoasis/nerd-fonts.git
-    dest: "{{ nerdfonts_git_dest }}"
-    depth: 1
-    version: master
-  when: false in nerdfonts_install_statuses
-  become: yes
-  become_user: root
+- name: '[Linux] Checkout nerdfonts'
+  include_tasks: checkout-fonts.yml
 
 - name: "[Linux] Install NerdFonts"
   command: "{{ nerdfonts_install_cmd }} {{ nerdfonts_git_dest }}/patched-fonts/{{ item.fontname }} {{ nerdfonts_install_dir }}"


### PR DESCRIPTION
## Summary

This PR adds configurable/automatic support for using `svn export` instead of `git clone` to checkout fonts from the upstream [nerd-fonts repository](https://github.com/ryanoasis/nerd-fonts).

By default, if `svn` is available, the role/playbook will use it instead of `git` to checkout the target font directory. This reduces the checkout time by up to several orders of magnitude (GBs vs MBs) for most use cases.

## Rationale

The existing logic uses a `git clone` of the repository, which in practice means the playbook is downloading 3+ GB of data any time a font needs to be installed.

If we were to stick with `git`, one option would be to use a `git archive` command to download the specific files needed. Unfortunately ,GitHub explicitly blocks the use of `git archive`.

Modern versions of `git` do support some options for sparse checkouts of single files with no history, but this feature isn't widely supported, and also does not seem to be supported by GitHub's implementation.

What GitHub does support is using Subersion (`svn`) to interact with their git repositories. `svn` allows users to checkout specific files/folders via the `svn export` command.

## Considerations

- It's been years since I've done any real Ansible work, so I might not be using best practices here
- I've also never used Molecule. I managed to get the existing test suite running, but haven't done any work to add new test suites to cover these changes.